### PR TITLE
v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [1.3.0] - 2020-10-27
+### Changes
+- `InjectToSceneObjects` can now optionally inject to inactive game objects (default behaviour is to include inactive objects)

--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fea1cff0705b48c9b2b0a0f4c85eb9f8
+timeCreated: 1603807071

--- a/Scripts/DependencyContainer.cs
+++ b/Scripts/DependencyContainer.cs
@@ -124,13 +124,13 @@ namespace UnityDependencyInjection
 			handler?.HandleDependencyInjectionComplete();
 		}
 
-		public void InjectToSceneObjects()
+		public void InjectToSceneObjects(bool includeInactiveObjects = true)
 		{
 			foreach (var injectable in injectableMonoBehaviours)
 			{
 				if (injectable.IgnoreSceneInjection) continue;
 
-				var injectableObjects = Object.FindObjectsOfType(injectable.MonoBehaviourType);
+				var injectableObjects = Object.FindObjectsOfType(injectable.MonoBehaviourType, includeInactiveObjects);
 				foreach (var injectableObject in injectableObjects)
 				{
 					if (injectableObject.GetType() != injectable.MonoBehaviourType) continue;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.kkjamie.unity-dependency-injection",
   "displayName": "UnityDependencyInjection",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes
- `InjectToSceneObjects` can now optionally inject to inactive game objects (default behaviour is to include inactive objects)